### PR TITLE
if only one admin, cannot demote or deactivate

### DIFF
--- a/src/components/users/UserEdit.js
+++ b/src/components/users/UserEdit.js
@@ -74,10 +74,10 @@ export const UserEdit = () => {
                                                     }
                                                 })
 
-                                                if(count === 1) {
+                                                if(count === 1 && editUser?.user?.is_staff === true) {
                                                     window.alert("You must make a new admin account before deactivating.")
                                                 }
-                                                if(count >= 2) {
+                                                if(count >= 2 || editUser?.user?.is_staff === false) {
                                                     const confirmBox = window.confirm("Confirm: Deactivate User")
                                                     if  (confirmBox)
                                                     updateUserActive(userId)

--- a/src/components/users/UserEdit.js
+++ b/src/components/users/UserEdit.js
@@ -1,17 +1,17 @@
 import { useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
-import { getUserById, updateUser, updateUserActive, updateUserStaff, updateUserStatus } from "../../managers/UserManager"
+import { getAllUsers, getUserById, updateUser, updateUserActive, updateUserStaff, updateUserStatus } from "../../managers/UserManager"
 
 export const UserEdit = () => {
     const navigate = useNavigate()
     const [editUser, setEditUser] = useState([])
     const { userId } = useParams()
+    const [users, setUsers] = useState([])    
 
     useEffect(() => {
         getUserById(userId).then(data => setEditUser(data))
+        getAllUsers().then(data => setUsers(data))
     }, [userId])
-    
-
 
     return (
         <>
@@ -28,10 +28,23 @@ export const UserEdit = () => {
                                     <button
                                     onClick={
                                         () => {
-                                            const confirmBox = window.confirm("Confirm: Demote User to 'Author'")
-                                            if  (confirmBox)
-                                            updateUserStaff(userId)
-                                        .then(() => navigate(`/users/${userId}`))
+                                                let count = 0
+
+                                                users.map(user => {
+                                                    if(user?.user?.is_staff === true) {
+                                                        count++
+                                                    }
+                                                })
+
+                                                if(count === 1) {
+                                                    window.alert("You must make a new admin account before demoting.")
+                                                }
+                                                if(count >= 2) {
+                                                    const confirmBox = window.confirm("Confirm: Demote User to 'Author'")
+                                                    if  (confirmBox)
+                                                    updateUserStaff(userId)
+                                                    .then(() => navigate(`/users/${userId}`))
+                                                }
                                     }}
                                     >Make Author</button>
                                     :
@@ -54,10 +67,22 @@ export const UserEdit = () => {
                                     <button
                                         onClick={
                                             () => {
-                                                const confirmBox = window.confirm("Confirm: Deactivate User")
-                                                if  (confirmBox)
-                                                updateUserActive(userId)
-                                            .then(() => navigate(`/users/${userId}`))
+                                                let count = 0
+                                                users.map(user => {
+                                                    if(user?.user?.is_staff === true) {
+                                                        count++
+                                                    }
+                                                })
+
+                                                if(count === 1) {
+                                                    window.alert("You must make a new admin account before deactivating.")
+                                                }
+                                                if(count >= 2) {
+                                                    const confirmBox = window.confirm("Confirm: Deactivate User")
+                                                    if  (confirmBox)
+                                                    updateUserActive(userId)
+                                                    .then(() => navigate(`/users/${userId}`))
+                                                }
                                         }}
                                     >Deactivate</button>
                                     :


### PR DESCRIPTION
Description
If there is only one admin account left, the admin cannot demote or deactivate their account without first making a new admin account.
**New feature (non-breaking change which adds functionality)**

How Has This Been Tested?
Log in as Carrie1945
If she is not already an admin, go to user list, edit Carrie and give admin privileges
After verifying Carrie is the only admin account, try to deactivate or make the account an author
Verify that you are getting an alert and are unable to deactivate/demote

Checklist:

 - [X] My code follows the style guidelines of this project
 - [X] I have performed a self-review of my own code
 - [X] I have commented my code, particularly in hard-to-understand areas
 - [X] My changes generate no new warnings